### PR TITLE
Converter enhancements

### DIFF
--- a/TomsToolbox.Wpf/Converters/ArithmeticMultiValueConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ArithmeticMultiValueConverter.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Collections.Generic;
@@ -8,6 +6,7 @@ namespace TomsToolbox.Wpf.Converters
     using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.Linq;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>
@@ -117,7 +116,7 @@ namespace TomsToolbox.Wpf.Converters
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(value), value, null);
+                        throw new ArgumentOutOfRangeException("value", value, null);
                 }
             }
         }

--- a/TomsToolbox.Wpf/Converters/BinaryOperationConverter.cs
+++ b/TomsToolbox.Wpf/Converters/BinaryOperationConverter.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
@@ -89,20 +88,22 @@ namespace TomsToolbox.Wpf.Converters
         private static readonly Func<object, object, object> _greaterThanOrEqualsMethod = (a, b) => ToDouble(a) >= ToDouble(b);
         private static readonly Func<object, object, object> _lessThanOrEqualsMethod = (a, b) => ToDouble(a) <= ToDouble(b);
 
-        private static Dictionary<Func<object, object, object>, Func<object, object, object>> _inverseOperations =
-            new Dictionary<Func<object, object, object>, Func<object, object, object>>();
+        private static readonly Dictionary<Func<object, object, object>, Func<object, object, object>> _inverseOperations;
 
         static BinaryOperationConverter() {
-            _inverseOperations.Add(_additionMethod, _subtractionMethod);
-            _inverseOperations.Add(_subtractionMethod, _additionMethod);
-            _inverseOperations.Add(_multiplyMethod, _divisionMethod);
-            _inverseOperations.Add(_divisionMethod, _multiplyMethod);
-            _inverseOperations.Add(_equalityMethod, _inequalityMethod);
-            _inverseOperations.Add(_inequalityMethod, _equalityMethod);
-            _inverseOperations.Add(_greaterThanMethod, _lessThanOrEqualsMethod);
-            _inverseOperations.Add(_lessThanOrEqualsMethod, _greaterThanMethod);
-            _inverseOperations.Add(_lessThanMethod, _greaterThanOrEqualsMethod);
-            _inverseOperations.Add(_greaterThanOrEqualsMethod, _lessThanMethod);
+            _inverseOperations = new Dictionary<Func<object, object, object>, Func<object, object, object>>
+            {
+                {_additionMethod, _subtractionMethod},
+                {_subtractionMethod, _additionMethod},
+                {_multiplyMethod, _divisionMethod},
+                {_divisionMethod, _multiplyMethod},
+                {_equalityMethod, null},
+                {_inequalityMethod, null},
+                {_greaterThanMethod, null},
+                {_lessThanOrEqualsMethod, null},
+                {_lessThanMethod, null},
+                {_greaterThanOrEqualsMethod, null}
+            };
         }
 
         private BinaryOperation _operation;
@@ -113,7 +114,12 @@ namespace TomsToolbox.Wpf.Converters
         {
             if (!inverse)
                 return _operationMethod;
-            return _inverseOperations[_operationMethod];
+            var inverseMethod  = _inverseOperations[_operationMethod];
+            if (inverseMethod == null)
+            {
+                throw new InvalidOperationException("The operation cannot be converted back.");
+            }
+            return inverseMethod;
         }
 
         /// <summary>
@@ -215,7 +221,7 @@ namespace TomsToolbox.Wpf.Converters
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(value), value, null);
+                        throw new ArgumentOutOfRangeException("value", value, null);
                 }
             }
         }

--- a/TomsToolbox.Wpf/Converters/BooleanToVisibilityConverter.cs
+++ b/TomsToolbox.Wpf/Converters/BooleanToVisibilityConverter.cs
@@ -1,15 +1,86 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System;
+using System.Globalization;
+using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System.Windows.Data;
 
     /// <summary>
-    /// A static class hosting a singleton instance of the <see cref="System.Windows.Controls.BooleanToVisibilityConverter"/>
+    /// The counterpart of VisibilityToBooleanConverter.
     /// </summary>
-    public static class BooleanToVisibilityConverter
+    [ValueConversion(typeof(bool), typeof(Visibility))]
+    public class BooleanToVisibilityConverter : IValueConverter
     {
         /// <summary>
         /// The singleton instance of the converter.
         /// </summary>
-        public static readonly IValueConverter Default = new System.Windows.Controls.BooleanToVisibilityConverter();
+        public static readonly IValueConverter Default = new BooleanToVisibilityConverter();
+
+        /// <summary>
+        /// The visibility value to be used when converting from a false bool value. Defaults to Collapsed.
+        /// </summary>
+        public Visibility VisibilityWhenBooleanIsFalse { get; set; }
+
+        /// <summary>
+        /// The visibility value to be used when converting from a null bool value. Defaults to Collapsed.
+        /// </summary>
+        public Visibility? VisibilityWhenBooleanIsNull { get; set; }
+
+        /// <summary>
+        /// The bool value to be used when converting from a null Visibility value. Defaults to false.
+        /// </summary>
+        public bool? BooleanWhenVisibilityIsNull { get; set; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public BooleanToVisibilityConverter() {
+            VisibilityWhenBooleanIsFalse = Visibility.Collapsed;
+            VisibilityWhenBooleanIsNull = Visibility.Collapsed;
+            BooleanWhenVisibilityIsNull = false;
+        }
+
+        /// <summary>
+        /// Converts a value.
+        /// True becomes Visible, false becomes the value set by VisibilityWhenBooleanIsFale, null becomes VisibilityWhenBooleanIsNull and UnSet is unchanged.
+        /// </summary>
+        /// <param name="value">The value that is produced by the binding target.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="parameter">The converter parameter to use.</param>
+        /// <param name="culture">The culture to use in the converter.</param>
+        /// <returns>
+        /// A converted value.
+        /// </returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+
+            if (value == null)
+                return VisibilityWhenBooleanIsNull;
+
+            return (bool)value ? Visibility.Visible : VisibilityWhenBooleanIsFalse;
+        }
+
+        /// <summary>
+        /// Converts a value.
+        /// Visible becomes true, Collapsed and Hidden become false, null becomes BooleanWhenVisibilityIsNull and UnSet is unchanged.
+        /// </summary>
+        /// <param name="value">The value that is produced by the binding target.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="parameter">The converter parameter to use.</param>
+        /// <param name="culture">The culture to use in the converter.</param>
+        /// <returns>
+        /// A converted value.
+        /// </returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+            if (value == null)
+                return BooleanWhenVisibilityIsNull;
+
+            return (Visibility)value == Visibility.Visible;
+        }
+
     }
 }

--- a/TomsToolbox.Wpf/Converters/BooleanToVisibilityConverter.cs
+++ b/TomsToolbox.Wpf/Converters/BooleanToVisibilityConverter.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Globalization;
-using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
+    using System;
+    using System.Globalization;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/ColorNameToBrushConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ColorNameToBrushConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
@@ -10,6 +12,7 @@
     /// <summary>
     /// Converts a color name to the corresponding solid color brush. See <see cref="BrushConverter"/> for supported values.
     /// </summary>
+    [ValueConversion(typeof(string), typeof(Brush))]
     public class ColorNameToBrushConverter : IValueConverter
     {
         private static readonly TypeConverter _typeConverter = new BrushConverter();
@@ -21,19 +24,14 @@
 
         /// <summary>
         /// Converts the specified color name.
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <param name="colorName">The color name.</param>
         /// <returns>The corresponding brush if the conversion was successful; otherwise <c>null</c>.</returns>
         public static Brush Convert(string colorName)
         {
-            try
-            {
-                return colorName != null ? _typeConverter.ConvertFromInvariantString(colorName) as Brush : null;
-            }
-            catch (NotSupportedException)
-            {
-                return null;
-            }
+            // let it fail fast so we are not left wondering what went wrong
+            return colorName != null ? _typeConverter.ConvertFromInvariantString(colorName) as Brush : null;
         }
 
         /// <summary>
@@ -48,7 +46,10 @@
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return Convert(value as string);
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
+
+            return Convert((string)value);
         }
 
         /// <summary>
@@ -61,10 +62,10 @@
         /// <returns>
         /// A converted value. If the method returns null, the valid null value is used.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="System.InvalidOperationException"></exception>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         [ContractInvariantMethod]

--- a/TomsToolbox.Wpf/Converters/ColorNameToBrushConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ColorNameToBrushConverter.cs
@@ -1,12 +1,11 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.Windows.Data;
+    using System.Windows;
     using System.Windows.Media;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/CompositeConverter.cs
+++ b/TomsToolbox.Wpf/Converters/CompositeConverter.cs
@@ -44,7 +44,7 @@
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (Converters == null || Converters.Count <= 0)
+            if (Converters.Count <= 0)
             {
                 throw new InvalidOperationException("One or more converters are required.");
             }
@@ -64,7 +64,7 @@
         /// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (Converters == null || Converters.Count <= 0) {
+            if (Converters.Count <= 0) {
                 throw new InvalidOperationException("One or more converters are required.");
             }
 

--- a/TomsToolbox.Wpf/Converters/CompositeConverter.cs
+++ b/TomsToolbox.Wpf/Converters/CompositeConverter.cs
@@ -12,6 +12,7 @@
     /// A converter composed of a chain of converters. The converters are invoked in the oder specified.
     /// </summary>
     [ContentProperty("Converters")]
+    [ValueConversion(typeof(object), typeof(object))]
     public class CompositeConverter : IValueConverter
     {
         private readonly Collection<IValueConverter> _converters = new Collection<IValueConverter>(new List<IValueConverter>());
@@ -39,10 +40,15 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
+            if (Converters == null || Converters.Count <= 0)
+            {
+                throw new InvalidOperationException("One or more converters are required.");
+            }
+
             return Converters.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
         }
 
@@ -54,10 +60,14 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
+            if (Converters == null || Converters.Count <= 0) {
+                throw new InvalidOperationException("One or more converters are required.");
+            }
+
             return Converters.Reverse().Aggregate(value, (current, converter) => converter.ConvertBack(current, targetType, parameter, culture));
         }
 

--- a/TomsToolbox.Wpf/Converters/CompositeMultiValueConverter.cs
+++ b/TomsToolbox.Wpf/Converters/CompositeMultiValueConverter.cs
@@ -14,6 +14,7 @@
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Multi", Justification = "Use the same term as in IMultiValueConverter")]
     [ContentProperty("Converters")]
+    [ValueConversion(typeof(object[]), typeof(object))]
     public class CompositeMultiValueConverter : IMultiValueConverter
     {
         private readonly CompositeConverter _compositeConverter = new CompositeConverter();
@@ -49,12 +50,12 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+        /// A converted value.
         /// </returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (MultiValueConverter == null)
-                return null;
+                throw new InvalidOperationException("A MultiValueConverter must be set.");
 
             return _compositeConverter.Convert(MultiValueConverter.Convert(values, targetType, parameter, culture), targetType, parameter, culture);
         }
@@ -69,10 +70,10 @@
         /// <returns>
         /// An array of values that have been converted from the target value back to the source values.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="System.InvalidOperationException"></exception>
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/ConfirmedCommandConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ConfirmedCommandConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
+    using System.Windows;
     using System.Windows.Data;
     using System.Windows.Input;
 
@@ -65,13 +64,15 @@ namespace TomsToolbox.Wpf.Converters
             Contract.Requires(e != null);
 
             var handler = Executing;
-            handler?.Invoke(this, e);
+            if (handler != null)
+                handler.Invoke(this, e);
         }
 
         private void OnError(ErrorEventArgs e)
         {
             var handler = Error;
-            handler?.Invoke(this, e);
+            if (handler != null)
+                handler.Invoke(this, e);
         }
 
         class CommandProxy : ICommand

--- a/TomsToolbox.Wpf/Converters/ConfirmedCommandConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ConfirmedCommandConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics.Contracts;
@@ -10,23 +12,26 @@
     /// <summary>
     /// A converter to use in <see cref="ICommand"/> bindings to intercept or filter command executions in the view layer in MVVM applications.
     /// </summary>
+    [ValueConversion(typeof(ICommand), typeof(CommandProxy))]
     public class ConfirmedCommandConverter : IValueConverter
     {
         /// <summary>
         /// Converts a value.
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var command = value as ICommand;
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
-            return command == null ? value : new CommandProxy(this, command);
+            return new CommandProxy(this, (ICommand)value);
         }
 
         /// <summary>
@@ -39,10 +44,10 @@
         /// <returns>
         /// A converted value. If the method returns null, the valid null value is used.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="System.InvalidOperationException"></exception>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         /// <summary>
@@ -60,15 +65,13 @@
             Contract.Requires(e != null);
 
             var handler = Executing;
-            if (handler != null)
-                handler(this, e);
+            handler?.Invoke(this, e);
         }
 
         private void OnError(ErrorEventArgs e)
         {
             var handler = Error;
-            if (handler != null)
-                handler(this, e);
+            handler?.Invoke(this, e);
         }
 
         class CommandProxy : ICommand

--- a/TomsToolbox.Wpf/Converters/CoordinatesToPointConverter.cs
+++ b/TomsToolbox.Wpf/Converters/CoordinatesToPointConverter.cs
@@ -10,6 +10,7 @@
     /// <summary>
     /// Converts WGS-84 coordinates into logical XY coordinates in the range 0..1 and back.
     /// </summary>
+    [ValueConversion(typeof(object), typeof(object))]
     public class CoordinatesToPointConverter : IValueConverter
     {
         /// <summary>
@@ -19,13 +20,14 @@
 
         /// <summary>
         /// Converts a value.
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -49,6 +51,9 @@
 
         private static object Convert(object value)
         {
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
+
             if (value is Point)
             {
                 return (Coordinates)(Point)value;
@@ -59,7 +64,7 @@
                 return (Point)(Coordinates)value;
             }
 
-            return null;
+            throw new ArgumentException("The value has to be a Point or a Coordinate.", nameof(value));
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/CoordinatesToPointConverter.cs
+++ b/TomsToolbox.Wpf/Converters/CoordinatesToPointConverter.cs
@@ -64,7 +64,7 @@
                 return (Point)(Coordinates)value;
             }
 
-            throw new ArgumentException("The value has to be a Point or a Coordinate.", nameof(value));
+            throw new ArgumentException("The value has to be a Point or a Coordinate.", "value");
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/DoubleToThicknessConverter.cs
+++ b/TomsToolbox.Wpf/Converters/DoubleToThicknessConverter.cs
@@ -9,6 +9,7 @@
     /// <summary>
     /// Converts a single number to a uniform <see cref="Thickness"/>, optionally multiplying with the thickness passed as converter parameter.
     /// </summary>
+    [ValueConversion(typeof(double), typeof(Thickness))]
     public class DoubleToThicknessConverter : IValueConverter
     {
         private static readonly TypeConverter _typeConverter = new ThicknessConverter();
@@ -20,41 +21,28 @@
 
         /// <summary>
         /// Converts a value. 
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param><param name="targetType">The type of the binding target property.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
+
             var thickness = ConvertNumberToThickness(value);
 
-            try
-            {
-                var factor = (parameter as Thickness?) ?? (_typeConverter.ConvertFromInvariantString(parameter as string) as Thickness?);
-
-                return ThicknessMultiplyConverter.Multiply(thickness, factor.GetValueOrDefault());
-            }
-            catch (SystemException)
-            {
-            }
-
-            return thickness;
+            return ThicknessMultiplyConverter.Default.Convert(thickness, targetType, parameter, culture);
         }
 
         private static Thickness ConvertNumberToThickness(object value)
         {
-            try
-            {
-                var length = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
-                var thickness = new Thickness(length);
-                return thickness;
-            }
-            catch (SystemException)
-            {
-            }
-
-            return new Thickness();
+            // let it fail fast so we are not left wondering what went wrong
+            var length = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            var thickness = new Thickness(length);
+            return thickness;
         }
 
         /// <summary>
@@ -66,7 +54,7 @@
         /// <param name="value">The value that is produced by the binding target.</param><param name="targetType">The type to convert to.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/DoubleToThicknessConverter.cs
+++ b/TomsToolbox.Wpf/Converters/DoubleToThicknessConverter.cs
@@ -12,8 +12,6 @@
     [ValueConversion(typeof(double), typeof(Thickness))]
     public class DoubleToThicknessConverter : IValueConverter
     {
-        private static readonly TypeConverter _typeConverter = new ThicknessConverter();
-
         /// <summary>
         /// The singleton instance of the converter.
         /// </summary>

--- a/TomsToolbox.Wpf/Converters/EnumToBooleanConverter.cs
+++ b/TomsToolbox.Wpf/Converters/EnumToBooleanConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Globalization;
     using System.Linq;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>
@@ -52,7 +51,7 @@ namespace TomsToolbox.Wpf.Converters
             var valueType = value.GetType();
             if (!valueType.IsEnum)
             {
-                throw new ArgumentException("The value is not an enum.", nameof(value));
+                throw new ArgumentException("The value is not an enum.", "value");
             }
 
             // do not catch exceptions and let it fail fast so we are not left wondering what happened

--- a/TomsToolbox.Wpf/Converters/EnumToBooleanConverter.cs
+++ b/TomsToolbox.Wpf/Converters/EnumToBooleanConverter.cs
@@ -1,8 +1,9 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
-    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using System.Windows.Data;
@@ -11,6 +12,7 @@
     /// Tests if an enum value matches one of the given values provides as the converter parameter. 
     /// If the enum has a <see cref="FlagsAttribute"/>, the match is done with the logic "is any flag set".
     /// </summary>
+    [ValueConversion(typeof(object), typeof(bool))]
     public class EnumToBooleanConverter : IValueConverter
     {
         /// <summary>
@@ -20,14 +22,18 @@
 
         /// <summary>
         /// Converts a value. 
+        /// UnSet is unchanged, null returns false.
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param><param name="targetType">The type of the binding target property.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return Convert(value, parameter as string);
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+
+            return Convert(value, (string)parameter);
         }
 
         /// <summary>
@@ -45,28 +51,19 @@
 
             var valueType = value.GetType();
             if (!valueType.IsEnum)
-                return false;
-
-            try
             {
-                var valueValue = System.Convert.ToInt64(value, CultureInfo.InvariantCulture);
-
-                var typeConverter = TypeDescriptor.GetConverter(value);
-                var matchesList = matches.Split(',').Select(typeConverter.ConvertFromInvariantString).Select(x => System.Convert.ToInt64(x, CultureInfo.InvariantCulture));
-
-                return Attribute.IsDefined(valueType, typeof(FlagsAttribute))
-                    ? matchesList.Any(x => (valueValue & x) != 0)
-                    : matchesList.Contains(valueValue);
-            }
-            catch (SystemException ex)
-            {
-                if (Debugger.IsAttached)
-                {
-                    Debug.Fail(ex.ToString());
-                }
+                throw new ArgumentException("The value is not an enum.", nameof(value));
             }
 
-            return false;
+            // do not catch exceptions and let it fail fast so we are not left wondering what happened
+            var valueValue = System.Convert.ToInt64(value, CultureInfo.InvariantCulture);
+
+            var typeConverter = TypeDescriptor.GetConverter(value);
+            var matchesList = matches.Split(',').Select(typeConverter.ConvertFromInvariantString).Select(x => System.Convert.ToInt64(x, CultureInfo.InvariantCulture));
+
+            return Attribute.IsDefined(valueType, typeof(FlagsAttribute))
+                ? matchesList.Any(x => (valueValue & x) != 0)
+                : matchesList.Contains(valueValue);
         }
 
         /// <summary>
@@ -78,7 +75,7 @@
         /// <param name="value">The value that is produced by the binding target.</param><param name="targetType">The type to convert to.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/EnumToValuesConverter.cs
+++ b/TomsToolbox.Wpf/Converters/EnumToValuesConverter.cs
@@ -1,12 +1,11 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Collections;
     using System.ComponentModel;
     using System.Globalization;
     using System.Linq;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/EnumToValuesConverter.cs
+++ b/TomsToolbox.Wpf/Converters/EnumToValuesConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Collections;
@@ -11,6 +13,7 @@
     /// Converts the specified enum-type into an array of the individual enum values.
     /// The converter parameter can be used to specify a comma separated exclude list.
     /// </summary>
+    [ValueConversion(typeof(Type), typeof(Array))]
     public class EnumToValuesConverter : IValueConverter
     {
         /// <summary>
@@ -20,24 +23,18 @@
 
         /// <summary>
         /// Converts a value. 
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param><param name="targetType">The type of the binding target property.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return Convert(value as Type, parameter as string);
-        }
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
-        /// <summary>
-        /// Converts the specified enum-type into an array of the individual enum values.
-        /// </summary>
-        /// <param name="type">The enum type.</param>
-        /// <returns>An array of the enum's values.</returns>
-        public static Array Convert(Type type)
-        {
-            return Convert(type, null);
+            return Convert((Type)value, (string)parameter);
         }
 
         /// <summary>
@@ -46,7 +43,7 @@
         /// <param name="type">The enum type.</param>
         /// <param name="excluded">A comma separated list of values to exclude.</param>
         /// <returns>An array of the enum's values.</returns>
-        public static Array Convert(Type type, string excluded)
+        public static Array Convert(Type type, string excluded = null)
         {
             if (type == null)
                 return null;
@@ -72,7 +69,7 @@
         /// <param name="value">The value that is produced by the binding target.</param><param name="targetType">The type to convert to.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/ImageSourceToImageConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ImageSourceToImageConverter.cs
@@ -1,10 +1,9 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Globalization;
     using System.Windows.Controls;
+    using System.Windows;
     using System.Windows.Data;
     using System.Windows.Media;
 

--- a/TomsToolbox.Wpf/Converters/ImageSourceToImageConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ImageSourceToImageConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Globalization;
@@ -10,6 +12,7 @@
     /// Converts an <see cref="ImageSource"/> into an <see cref="Image"/>. 
     /// Needed to assign an image source to an item via a style setter, e.g. <see cref="MenuItem.Icon"/>.
     /// </summary>
+    [ValueConversion(typeof(ImageSource), typeof(ImageSource))]
     public class ImageSourceToImageConverter : IValueConverter
     {
         /// <summary>
@@ -19,21 +22,21 @@
 
         /// <summary>
         /// Converts a value.
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var imageSource = value as ImageSource;
-            if (imageSource == null)
-                return null;
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
-            return new Image { Source = imageSource };
+            return new Image { Source = (ImageSource)value };
         }
 
         /// <summary>
@@ -46,10 +49,10 @@
         /// <returns>
         /// A converted value. If the method returns null, the valid null value is used.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="System.InvalidOperationException"></exception>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/LogicalMultiValueConverter.cs
+++ b/TomsToolbox.Wpf/Converters/LogicalMultiValueConverter.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Collections.Generic;
@@ -8,6 +6,7 @@ namespace TomsToolbox.Wpf.Converters
     using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.Linq;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>
@@ -74,7 +73,7 @@ namespace TomsToolbox.Wpf.Converters
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(value), value, null);
+                        throw new ArgumentOutOfRangeException("value", value, null);
                 }
             }
         }

--- a/TomsToolbox.Wpf/Converters/LogicalMultiValueConverter.cs
+++ b/TomsToolbox.Wpf/Converters/LogicalMultiValueConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Collections.Generic;
@@ -30,6 +32,7 @@
     /// All items must be convertible to boolean.
     /// </remarks>
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Multi", Justification = "Use the same term as in IMultiValueConverter")]
+    [ValueConversion(typeof(object[]), typeof(bool))]
     public class LogicalMultiValueConverter : IMultiValueConverter
     {
         private static readonly Func<IEnumerable<bool>, bool> _andOperationMethod = items => items.All(item => item);
@@ -71,35 +74,32 @@
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException("value", value, null);
+                        throw new ArgumentOutOfRangeException(nameof(value), value, null);
                 }
             }
         }
 
         /// <summary>
         /// Converts source values to a value for the binding target. The data binding engine calls this method when it propagates the values from source bindings to the binding target.
+        /// An input value of null will return null, whereas if the input array contains UnSet then UnSet will be returned.
         /// </summary>
         /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+        /// A converted value.
         /// </returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null)
-                return false;
+            if (values == null || values == DependencyProperty.UnsetValue)
+                return values;
+            if (values.Any(x => x == null))
+                return null;
+            if (values.Any(x => x == DependencyProperty.UnsetValue))
+                return DependencyProperty.UnsetValue;
 
-            try
-            {
-                return _operationMethod(values.Select(v => System.Convert.ToBoolean(v, CultureInfo.InvariantCulture)));
-            }
-            catch (SystemException)
-            {
-            }
-
-            return false;
+            return _operationMethod(values.Select(v => System.Convert.ToBoolean(v, CultureInfo.InvariantCulture)));
         }
 
         /// <summary>
@@ -112,10 +112,10 @@
         /// <returns>
         /// An array of values that have been converted from the target value back to the source values.
         /// </returns>
-        /// <exception cref="System.NotImplementedException"></exception>
+        /// <exception cref="System.InvalidOperationException"></exception>
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         [ContractInvariantMethod]

--- a/TomsToolbox.Wpf/Converters/ObjectToAttributeConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToAttributeConverter.cs
@@ -84,7 +84,7 @@
         /// Converts a value. 
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param><param name="targetType">The type of the binding target property.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public abstract object Convert(object value, Type targetType, object parameter, CultureInfo culture);
@@ -97,11 +97,11 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/ObjectToDescriptionConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToDescriptionConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
     using System.Globalization;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/ObjectToDescriptionConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToDescriptionConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
@@ -21,6 +23,7 @@
     /// Assert.Equals("This is item 1", ObjectToDescriptionConverter.Convert(Items.Item1));
     /// </code></example>
     /// <remarks>Works with any object; for enum types the attribute of the field is returned.</remarks>
+    [ValueConversion(typeof(object), typeof(string))]
     public class ObjectToDescriptionConverter : ObjectToAttributeConverter<DescriptionAttribute>
     {
         /// <summary>
@@ -30,6 +33,7 @@
 
         /// <summary>
         /// Converts a value.
+        /// UnSet is unchanged, null becomes an empty string.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
@@ -40,6 +44,9 @@
         /// </returns>
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+
             return value == null ? string.Empty : Convert(value, parameter as Type);
         }
 

--- a/TomsToolbox.Wpf/Converters/ObjectToDisplayNameConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToDisplayNameConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
@@ -21,6 +23,7 @@
     /// Assert.Equals("This is item 1", ObjectToDisplayNameConverter.Convert(Items.Item1));
     /// </code></example>
     /// <remarks>Works with any object; for enum types the attribute of the field is returned.</remarks>
+    [ValueConversion(typeof(object), typeof(string))]
     public class ObjectToDisplayNameConverter : ObjectToAttributeConverter<DisplayNameAttribute>
     {
         /// <summary>
@@ -30,16 +33,20 @@
 
         /// <summary>
         /// Converts a value.
+        /// UnSet is unchanged, null becomes an empty string.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+
             return value == null ? string.Empty : Convert(value, parameter as Type);
         }
 

--- a/TomsToolbox.Wpf/Converters/ObjectToDisplayNameConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToDisplayNameConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
     using System.Globalization;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/ObjectToTextConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToTextConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics.Contracts;
@@ -23,6 +25,7 @@
     /// Assert.AreEqual("This is item 1", ObjectToTextConverter.Convert("key1", Items.Item1));
     /// </code></example>
     /// <remarks>Works with any object; for enum types the attribute of the field is returned. When used via the <see cref="IValueConverter"/> interface, the key is specified as the converter parameter.</remarks>
+    [ValueConversion(typeof(object), typeof(string))]
     public class ObjectToTextConverter : ObjectToAttributeConverter<TextAttribute>
     {
         /// <summary>
@@ -42,16 +45,20 @@
 
         /// <summary>
         /// Converts a value.
+        /// UnSet is unchanged, null becomes an empty string.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+
             return value == null ? string.Empty : Convert(parameter ?? Key, value, null);
         }
 

--- a/TomsToolbox.Wpf/Converters/ObjectToTextConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ObjectToTextConverter.cs
@@ -1,10 +1,9 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics.Contracts;
     using System.Globalization;
+    using System.Windows;
     using System.Windows.Data;
 
     using TomsToolbox.Desktop;

--- a/TomsToolbox.Wpf/Converters/ReplaceTextConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ReplaceTextConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics;
@@ -9,6 +11,7 @@
     /// <summary>
     /// A converter that converts the specified value by replacing text using a regular expression.
     /// </summary>
+    [ValueConversion(typeof(string), typeof(string))]
     public class ReplaceTextConverter : IValueConverter
     {
         /// <summary>
@@ -70,18 +73,21 @@
 
         /// <summary>
         /// Converts a value.
+        /// Null and UnSet are unchanged.
         /// </summary>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var stringValue = value as string;
-            return stringValue == null ? value : Convert(stringValue);
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
+
+            return Convert((string)value);
         }
 
         /// <summary>
@@ -97,7 +103,7 @@
         /// <exception cref="System.NotImplementedException"></exception>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/ReplaceTextConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ReplaceTextConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.Diagnostics;
     using System.Globalization;
     using System.Text.RegularExpressions;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>

--- a/TomsToolbox.Wpf/Converters/StringToObjectConverter.cs
+++ b/TomsToolbox.Wpf/Converters/StringToObjectConverter.cs
@@ -1,11 +1,10 @@
-﻿using System.Windows;
-
-namespace TomsToolbox.Wpf.Converters
+﻿namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Windows;
     using System.Windows.Data;
 
     /// <summary>
@@ -29,7 +28,9 @@ namespace TomsToolbox.Wpf.Converters
         {
             get
             {
-                return _typeConverter?.GetType();
+                if (_typeConverter != null)
+                    return _typeConverter.GetType();
+                return null;
             }
             set
             {
@@ -77,7 +78,8 @@ namespace TomsToolbox.Wpf.Converters
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"{typeConverter} failed to convert '{value}': {ex.Message}");
+                throw new InvalidOperationException(string.Format("{0} failed to convert '{1}': {2}", typeConverter,
+                    value, ex.Message));
             }
         }
 
@@ -106,7 +108,8 @@ namespace TomsToolbox.Wpf.Converters
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"{typeConverter} failed to convert '{value}': {ex.Message}");
+                throw new InvalidOperationException(string.Format("{0} failed to convert '{1}': {2}", typeConverter,
+                    value, ex.Message));
             }
         }
 

--- a/TomsToolbox.Wpf/Converters/StringToObjectConverter.cs
+++ b/TomsToolbox.Wpf/Converters/StringToObjectConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace TomsToolbox.Wpf.Converters
+﻿using System.Windows;
+
+namespace TomsToolbox.Wpf.Converters
 {
     using System;
     using System.ComponentModel;
@@ -9,6 +11,7 @@
     /// <summary>
     /// A <see cref="IValueConverter" /> wrapping a <see cref="TypeConverter" />
     /// </summary>
+    [ValueConversion(typeof(string), typeof(object))]
     public class StringToObjectConverter : IValueConverter
     {
         private TypeConverter _typeConverter;
@@ -26,7 +29,7 @@
         {
             get
             {
-                return _typeConverter != null ? _typeConverter.GetType() : null;
+                return _typeConverter?.GetType();
             }
             set
             {
@@ -46,10 +49,10 @@
         }
 
         /// <summary>
-        /// Converts a value.
+        /// Converts a value. Null or UnSet are unchanged.
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param>
         /// <param name="targetType">The type of the binding target property.</param>
@@ -57,8 +60,8 @@
         /// <param name="culture">The culture to use in the converter.</param>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
-                return null;
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
             var typeConverter = GetTypeConverter(targetType);
             if (typeConverter == null)
@@ -74,8 +77,7 @@
             }
             catch (Exception ex)
             {
-                Trace.TraceError("{0} failed to convert '{1}': {2}", typeConverter, value, ex.Message);
-                return null;
+                throw new InvalidOperationException($"{typeConverter} failed to convert '{value}': {ex.Message}");
             }
         }
 
@@ -91,8 +93,8 @@
         /// <param name="culture">The culture to use in the converter.</param>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
-                return null;
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
             var typeConverter = GetTypeConverter(targetType);
             if (typeConverter == null)
@@ -104,8 +106,7 @@
             }
             catch (Exception ex)
             {
-                Trace.TraceError("{0} failed to convert '{1}': {2}", typeConverter, value, ex.Message);
-                return null;
+                throw new InvalidOperationException($"{typeConverter} failed to convert '{value}': {ex.Message}");
             }
         }
 

--- a/TomsToolbox.Wpf/Converters/ThicknessMultiplyConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ThicknessMultiplyConverter.cs
@@ -66,7 +66,7 @@
             }
             else
             {
-                throw new ArgumentException("Invalid thickness parameter.", nameof(parameter));
+                throw new ArgumentException("Invalid thickness parameter.", "parameter");
             }
 
             return Multiply(target, factor);

--- a/TomsToolbox.Wpf/Converters/ThicknessMultiplyConverter.cs
+++ b/TomsToolbox.Wpf/Converters/ThicknessMultiplyConverter.cs
@@ -10,6 +10,7 @@
     /// Multiplies all corresponding members of two <see cref="Thickness"/>. structures. 
     /// The first structure is passed as the converter value, the second as the converter parameter.
     /// </summary>
+    [ValueConversion(typeof(Thickness), typeof(Thickness))]
     public class ThicknessMultiplyConverter : IValueConverter
     {
         private static readonly TypeConverter _typeConverter = new ThicknessConverter();
@@ -38,38 +39,49 @@
 
         /// <summary>
         /// Converts a value. 
+        /// Null or UnSet are unchanged, a Thickness is multiplied by the Thickness in the parameter.
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value produced by the binding source.</param><param name="targetType">The type of the binding target property.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var target = (value as Thickness?).GetValueOrDefault();
+            if (value == null || value == DependencyProperty.UnsetValue)
+                return value;
 
-            try
+            var target = (Thickness)value;
+            Thickness factor;
+            if (parameter == null)
             {
-                var factor = (parameter as Thickness?) ?? (_typeConverter.ConvertFromInvariantString(parameter as string) as Thickness?);
-
-                return Multiply(target, factor.GetValueOrDefault());
+                factor = new Thickness(1.0);
             }
-            catch
+            else if (parameter is Thickness)
             {
+                factor = (Thickness) parameter;
+            }
+            else if (parameter is string)
+            {
+                factor = (Thickness) _typeConverter.ConvertFromInvariantString((string) parameter);
+            }
+            else
+            {
+                throw new ArgumentException("Invalid thickness parameter.", nameof(parameter));
             }
 
-            return target;
+            return Multiply(target, factor);
         }
 
         /// <summary>
         /// Converts a value. 
         /// </summary>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value.
         /// </returns>
         /// <param name="value">The value that is produced by the binding target.</param><param name="targetType">The type to convert to.</param><param name="parameter">The converter parameter to use.</param><param name="culture">The culture to use in the converter.</param>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/VisibilityToBooleanConverter.cs
+++ b/TomsToolbox.Wpf/Converters/VisibilityToBooleanConverter.cs
@@ -8,12 +8,19 @@
     /// <summary>
     /// The counterpart of BooleanToVisibilityConverter.
     /// </summary>
+    [ValueConversion(typeof(Visibility), typeof(bool))]
     public class VisibilityToBooleanConverter : IValueConverter
     {
         /// <summary>
         /// The singleton instance of the converter.
         /// </summary>
         public static readonly IValueConverter Default = new VisibilityToBooleanConverter();
+        
+        public Visibility VisibilityWhenFalse { get; set; }
+        
+        public VisibilityToBooleanConverter() {
+            VisibilityWhenFalse = Visibility.Collapsed;
+        }
 
         /// <summary>
         /// Converts a value.
@@ -23,12 +30,12 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value. If the value is null or Unset then the value is unchanged.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
-                return false;
+            if (value == null || value == DependencyProperty.Unset)
+                return value;
 
             return ((Visibility)value == Visibility.Visible);
         }
@@ -41,11 +48,14 @@
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the method returns null, the valid null value is used.
+        /// A converted value. If the value is null or Unset then the value is unchanged.
         /// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return ((value != null) && (bool)value) ? Visibility.Visible : Visibility.Collapsed;
+            if (value == null || value == DependencyProperty.Unset)
+                return value;
+
+            return ((bool)value) ? Visibility.Visible : VisibilityWhenFalse;
         }
     }
 }

--- a/TomsToolbox.Wpf/Converters/VisibilityToBooleanConverter.cs
+++ b/TomsToolbox.Wpf/Converters/VisibilityToBooleanConverter.cs
@@ -15,47 +15,71 @@
         /// The singleton instance of the converter.
         /// </summary>
         public static readonly IValueConverter Default = new VisibilityToBooleanConverter();
-        
-        public Visibility VisibilityWhenFalse { get; set; }
-        
-        public VisibilityToBooleanConverter() {
-            VisibilityWhenFalse = Visibility.Collapsed;
-        }
 
         /// <summary>
-        /// Converts a value.
+        /// The visibility value to be used when converting from a false bool value. Defaults to Collapsed.
         /// </summary>
-        /// <param name="value">The value produced by the binding source.</param>
-        /// <param name="targetType">The type of the binding target property.</param>
-        /// <param name="parameter">The converter parameter to use.</param>
-        /// <param name="culture">The culture to use in the converter.</param>
-        /// <returns>
-        /// A converted value. If the value is null or Unset then the value is unchanged.
-        /// </returns>
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null || value == DependencyProperty.Unset)
-                return value;
+        public Visibility VisibilityWhenBooleanIsFalse { get; set; }
 
-            return ((Visibility)value == Visibility.Visible);
+        /// <summary>
+        /// The visibility value to be used when converting from a null bool value. Defaults to Collapsed.
+        /// </summary>
+        public Visibility? VisibilityWhenBooleanIsNull { get; set; }
+
+        /// <summary>
+        /// The bool value to be used when converting from a null Visibility value. Defaults to false.
+        /// </summary>
+        public bool? BooleanWhenVisibilityIsNull { get; set; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public VisibilityToBooleanConverter() {
+            VisibilityWhenBooleanIsFalse = Visibility.Collapsed;
+            VisibilityWhenBooleanIsNull = Visibility.Collapsed;
+            BooleanWhenVisibilityIsNull = false;
         }
 
         /// <summary>
         /// Converts a value.
+        /// Visible becomes true, Collapsed and Hidden become false, null becomes BooleanWhenVisibilityIsNull and UnSet is unchanged.
         /// </summary>
         /// <param name="value">The value that is produced by the binding target.</param>
         /// <param name="targetType">The type to convert to.</param>
         /// <param name="parameter">The converter parameter to use.</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>
-        /// A converted value. If the value is null or Unset then the value is unchanged.
+        /// A converted value.
+        /// </returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value == DependencyProperty.UnsetValue)
+                return value;
+            if (value == null)
+                return BooleanWhenVisibilityIsNull;
+
+            return (Visibility)value == Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Converts a value.
+        /// True becomes Visible, false becomes the value set by VisibilityWhenBooleanIsFale, null becomes VisibilityWhenBooleanIsNull and UnSet is unchanged.
+        /// </summary>
+        /// <param name="value">The value that is produced by the binding target.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="parameter">The converter parameter to use.</param>
+        /// <param name="culture">The culture to use in the converter.</param>
+        /// <returns>
+        /// A converted value.
         /// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null || value == DependencyProperty.Unset)
+            if (value == DependencyProperty.UnsetValue)
                 return value;
 
-            return ((bool)value) ? Visibility.Visible : VisibilityWhenFalse;
+            if (value == null)
+                return VisibilityWhenBooleanIsNull;
+
+            return (bool)value ? Visibility.Visible : VisibilityWhenBooleanIsFalse;
         }
     }
 }


### PR DESCRIPTION
- Better return values for null and UnSet
- BooleanToVisibilityConverter and VisibilityToBoolean Converter now support these properties:
  **VisibilityWhenBooleanIsFalse** = Collapsed
  **VisibilityWhenBooleanIsNull** = Collapsed
  **BooleanWhenVisibilityIsNull** = false
- Made converters fail fast most times instead of swallowing exceptions on errors
- Added >= and <= to binary operations.
- Added Product arithmetic operation.
- First implementation of ConvertBack for binary operation, but not yet functional, so disabled in code.
  _(If you could take a look at it because I'm not sure where inverse should be plugged in for ApplyOperation and ApplyOperationOnCastedObject)_
