### PR TITLE
Fix not being able to change advanced scroll behavior after setting it

### DIFF
--- a/src/TomsToolbox.Wpf/Interactivity/AdvancedScrollWheelBehavior.cs
+++ b/src/TomsToolbox.Wpf/Interactivity/AdvancedScrollWheelBehavior.cs
@@ -83,6 +83,7 @@ public class AdvancedScrollWheelBehavior : FrameworkElementBehavior<FrameworkEle
 
     private bool _lastScrollWasTouchPad;
     private int _lastScrollingTick;
+    private bool _hasSubscribedToEvents;
 
     private uint _animationIdCounter;
     private DoubleAnimation? _currentAnimation;
@@ -93,6 +94,40 @@ public class AdvancedScrollWheelBehavior : FrameworkElementBehavior<FrameworkEle
     {
         base.OnAssociatedObjectLoaded();
 
+        SetupScrollViewer();
+    }
+
+    /// <inheritdoc />
+    protected override void OnAssociatedObjectUnloaded()
+    {
+        base.OnAssociatedObjectUnloaded();
+
+        UnloadScrollViewer();
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        
+        // Also call SetupScrollViewer here, because the object may already be loaded when the behavior is attached.
+        SetupScrollViewer();
+    }
+    
+    /// <inheritdoc />
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        
+        // Also call UnloadScrollViewer here, because the object may still be loaded when the behavior is detached.
+        UnloadScrollViewer();
+    }
+
+    private void SetupScrollViewer()
+    {
+        if (_hasSubscribedToEvents)
+            return;
+        
         _scrollViewer = AssociatedObject.VisualDescendantsAndSelf().OfType<ScrollViewer>().FirstOrDefault();
 
         if (_scrollViewer == null)
@@ -103,18 +138,20 @@ public class AdvancedScrollWheelBehavior : FrameworkElementBehavior<FrameworkEle
 
         _horizontalOffsetTarget = _scrollViewer.HorizontalOffset;
         _verticalOffsetTarget = _scrollViewer.VerticalOffset;
+
+        _hasSubscribedToEvents = true;
     }
-
-    /// <inheritdoc />
-    protected override void OnAssociatedObjectUnloaded()
+    
+    private void UnloadScrollViewer()
     {
-        base.OnAssociatedObjectUnloaded();
-
         if (_scrollViewer == null)
             return;
 
         _scrollViewer.PreviewMouseWheel -= ScrollViewer_PreviewMouseWheel;
         _scrollViewer.ScrollChanged -= ScrollViewer_ScrollChanged;
+
+        _scrollViewer = null;
+        _hasSubscribedToEvents = false;
     }
 
     #region DependencyProperties


### PR DESCRIPTION
When setting a scroll behavior on an element it will remain that way forever. This fixes that by making sure the scroll events are properly subscribed to and unsubscribed when the behavior is removed. It was getting callbacks from an object that didn't exist, and that for some reason caused it to never update the scroll behavior. 
This is obviously a bug fix, but also really helpful if you need to add a toggle for smooth scrolling your application.